### PR TITLE
bashrc: do not set BOOST_LIBRARYDIR or LD_LIBRARY_PATH

### DIFF
--- a/cookbooks/impala/files/default/bashrc
+++ b/cookbooks/impala/files/default/bashrc
@@ -110,8 +110,6 @@ SSH_ENV="$HOME/.ssh/environment"
 export PATH=/usr/lib/ccache:$PATH
 export GERRIT_USER=
 export JAVA_HOME=/usr/lib/jvm/java-7-oracle-amd64
-export BOOST_LIBRARYDIR=/usr/lib/x86_64-linux-gnu
-export LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu:$LD_LIBRARY_PATH
 export LC_ALL="en_US.UTF-8"
 
 clear


### PR DESCRIPTION
With this commit:

https://github.com/cloudera/Impala/commit/616830dc00bffa954110bb30afce96f6cdc763a4

...the setting of these variables can break dynamic library resolution.
For instance, the wrong libstdc++ may be used. No longer set them in
bashrc.
