### PR TITLE
Add libkrb5-dev package

### DIFF
--- a/cookbooks/impala/recipes/packages.rb
+++ b/cookbooks/impala/recipes/packages.rb
@@ -21,7 +21,7 @@ when "debian"
          "libssl-dev", "subversion", "libevent1-dev", "libsasl2-dev", "libldap2-dev",
          "liblzo2-dev", "lzop", "maven", "libboost-all-dev", "ccache", "python-pycurl",
 	 "libgnutls-dev", "libgnutls-dev", "python-pycurl", "wget", "ntp",
-         "libncurses5-dev" ]
+         "libncurses5-dev", "libkrb5-dev" ]
     packages.each do |pkg|
       package pkg
     end


### PR DESCRIPTION
The package is needed to compile Kudu and thus the toolchain.