### PR TITLE
Update to JDK8

### DIFF
--- a/cookbooks/impala/attributes/default.rb
+++ b/cookbooks/impala/attributes/default.rb
@@ -11,7 +11,7 @@ default['impala_dev']['username'] = username
 
 # Java options
 default['java']['install_flavor'] = 'oracle'
-default['java']['jdk_version'] = '7'
+default['java']['jdk_version'] = '8'
 default['java']['oracle']['accept_oracle_download_terms'] = true
 
 # Postgres options


### PR DESCRIPTION
Oracle is no longer distributing JDK7 as freely.

I have not tested this.